### PR TITLE
Home Intent: touch sentences.ini to clear out example sentences

### DIFF
--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
 set -e
+
+# clears the default (example) sentences.ini file for folks using the embedded system
+mkdir -p /profiles/en && touch /profiles/en/sentences.ini
+
 /usr/lib/rhasspy/bin/rhasspy-voltron --user-profiles /profiles --profile en &
 supervisord --configuration /usr/src/app/setup/supervisord.conf


### PR DESCRIPTION
For folks using the embedded rhasspy, touch the sentences.ini file to clear out the example sentences. Decided to go in setup.sh to avoid another docker build step.

helps out #120 