### PR TITLE
Home Intent: Disable cancel word (for now...)

### DIFF
--- a/home_intent/default_configs/arm/rhasspy_profile.json
+++ b/home_intent/default_configs/arm/rhasspy_profile.json
@@ -16,9 +16,6 @@
         "system": "aplay"
     },
     "speech_to_text": {
-        "kaldi": {
-            "cancel_word": "nevermind"
-        },
         "system": "kaldi"
     },
     "text_to_speech": {

--- a/home_intent/default_configs/x86_64/rhasspy_profile.json
+++ b/home_intent/default_configs/x86_64/rhasspy_profile.json
@@ -16,9 +16,6 @@
         "system": "aplay"
     },
     "speech_to_text": {
-        "kaldi": {
-            "cancel_word": "nevermind"
-        },
         "system": "kaldi"
     },
     "text_to_speech": {


### PR DESCRIPTION
After a lot of testing over the past few weeks, we can't quite tune this to work in a way that the testers found reliable enough to ship. Worst case scenario was very long wait past the cancel word where nothing would happen.

We definitely want to revisit this as it can be a big help in improving the experience overall, but we couldn't quite get it to work well enough for it yet.