### PR TITLE
Home Intent: Load language from environment variable

### DIFF
--- a/home_intent/__main__.py
+++ b/home_intent/__main__.py
@@ -45,6 +45,7 @@ def main():
     _setup_logging()
     settings = Settings()
     home_intent = HomeIntent(settings)
+    logging.info(f"Using language: {home_intent.language}")
     _load_integrations(settings, home_intent)
     home_intent.initialize()
 

--- a/home_intent/default_configs/de/home_assistant/color_names.yaml
+++ b/home_intent/default_configs/de/home_assistant/color_names.yaml
@@ -33,7 +33,7 @@ color_names:
   Dunkles Olivgrün: darkolivegreen
   Dunkles Orange: darkorange
   Dunkles Schieferblau: darkslateblue
-  Dunkles Schiefergrau: darkslateyellow
+  Dunkles Schiefergrau: darkslategrey
   Dunkles Seegrün: darkseagreen
   Eisfarben: aliceblue
   Elfenbein: ivory

--- a/home_intent/default_configs/en/home_assistant/color_names.yaml
+++ b/home_intent/default_configs/en/home_assistant/color_names.yaml
@@ -34,7 +34,7 @@ color_names:
   Dark Salmon: darksalmon
   Dark Sea Green: darkseagreen
   Dark Slate Blue: darkslateblue
-  Dark Slate Gray: darkslategray
+  Dark Slate Gray: darkslategrey
   Dark Turquoise: darkturquoise
   Dark Violet: darkviolet
   Deep Pink: deeppink

--- a/home_intent/default_configs/es/home_assistant/color_names.yaml
+++ b/home_intent/default_configs/es/home_assistant/color_names.yaml
@@ -61,7 +61,7 @@ color_names:
   Gris Oscuro: darkgrey
   Gris Oscuro: dimgrey
   Gris Pizarra Brillante: lightslategrey
-  Gris Pizarra Oscuro: darkslateyellow
+  Gris Pizarra Oscuro: darkslategrey
   Gris Pizarra: slategrey
   Gris: gray
   Gris: grey

--- a/home_intent/default_configs/fr/home_assistant/color_names.yaml
+++ b/home_intent/default_configs/fr/home_assistant/color_names.yaml
@@ -56,7 +56,7 @@ color_names:
   Fuchsia: fuchsia
   Gainsboro: gainsboro
   Gris Ardoise Brillant: lightslategrey
-  Gris Ardoise Foncé: darkslateyellow
+  Gris Ardoise Foncé: darkslategrey
   Gris Ardoise: slategrey
   Gris Clair: lightgray
   Gris Foncé: darkgrey

--- a/home_intent/settings.py
+++ b/home_intent/settings.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -6,6 +7,11 @@ import yaml
 
 # diabled for the Settings object as pydantic passes init/env settings in
 # pylint: disable=unused-argument
+
+
+# the ISO639_1 codes supported in Rhasspy using Kaldi
+# Source: https://rhasspy.readthedocs.io/en/latest/#supported-languages
+ISO639_1 = frozenset(["en", "de", "es", "fr", "it", "nl", "ru", "vi", "sv", "cs"])
 
 
 def yaml_config_settings_source(settings: BaseSettings) -> Dict[str, Any]:
@@ -36,11 +42,26 @@ class RhasspySettings(BaseModel):
     externally_managed: bool = False
 
 
+def get_env_language() -> str:
+    set_language = os.environ.get("LANGUAGE")
+    if set_language is None:
+        return "en"
+
+    # this is a bit of overkill and maybe not the best use of time
+    iso639_1 = [x for x in set_language.split(":") if x in ISO639_1]
+    if any(iso639_1):
+        return iso639_1[0]
+
+    return "en"
+
+
 class HomeIntentSettings(BaseModel):
     beeps: bool = True
     enable_beta: bool = False
     enable_all: bool = False
-    language: str = "en"
+
+    # there might be nested env var support one day: https://github.com/samuelcolvin/pydantic/pull/3159
+    language: str = get_env_language()
 
 
 class Settings(BaseSettings):

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -2,7 +2,7 @@
 set -e
 
 # clears the default (example) sentences.ini file for folks using the embedded system
-mkdir -p /profiles/en && echo -n > /profiles/en/sentences.ini
+mkdir -p /profiles/${LANGUAGE} && echo -n > /profiles/${LANGUAGE}/sentences.ini
 
-/usr/lib/rhasspy/bin/rhasspy-voltron --user-profiles /profiles --profile en &
+/usr/lib/rhasspy/bin/rhasspy-voltron --user-profiles /profiles --profile ${LANGUAGE} &
 supervisord --configuration /usr/src/app/setup/supervisord.conf


### PR DESCRIPTION
* Load a supported (Rhasspy w/Kaldi for now) language from an env variable
* Start Rhasspy with the correct language profile

This is in support of #162 