### PR TITLE
Home Intent: Initial satellites support

### DIFF
--- a/docs/docs/reference/api/home-intent-object.md
+++ b/docs/docs/reference/api/home-intent-object.md
@@ -42,8 +42,26 @@ In the example above, Home Intent will check for the file in `/config/home_assis
 ### Conventions
 When loading a file related to a component, it's best to put it in a folder that references the component's name. In the example above, files will be loaded from the `home_assistant` folder in `/config` or Home Intent's `default_configs` folder.
 
-## `home_intent.say(str)`
-Have Home Intent say something to the user. This method will likely be modified a bit when satellite support is enabled so a sentence is said at the right location.
+## `home_intent.say(str, satellite_id)`
+Have Home Intent say something to the user. This method takes in a `satellite_id` so it is said at the correct location. To get the satellite id where an intent is spoken, a decorator can be added to the intent function above the `sentences` decorator and the `satellite_id` will get passed into the function on execution:
+
+```python hl_lines="1 10"
+    @intents.satellite_id
+    @intents.sentences(
+        [
+            "time = 0..128",
+            "set timer [(<time>){hours} hours] [(<time>){minutes} minutes] [(<time>){seconds} seconds]",
+        ]
+    )
+    def set_timer(
+        self,
+        satellite_id,
+        hours: int = None,
+        minutes: int = None,
+        seconds: int = None,
+        timer_partial_time=None,
+    ):
+```
 
 ## `home_intent.play_audio_file(filename, language_dependent=False)`
 This will load a `.wav` file from the filename using the [`get_file`](./home-intent-object.md#home_intentget_filefilename-language_dependenttrue) and play it back using Home Intent. It can also take in the `language_dependent` flag (but defaults to `False`) to load audio files specific to a language if needed.

--- a/docs/docs/reference/api/intents-class.md
+++ b/docs/docs/reference/api/intents-class.md
@@ -88,6 +88,8 @@ In the example `shopping_item` is expected to be passed in to the `add_item_to_s
 
 and we're still figuring out how sentences that return state information should work, as very few of these are currently implemented.
 
+## `@intents.satellite_id`
+This decorator will pass in the `satellite_id` of the area that the sentence is spoken. This is useful if you need to [`say`](./home-intent-object.md#home_intentsaystr-satellite_id) something to the user at a later time.
 
 ## `@intents.on_event("register_sentences")`
 This method registers a callback method that will be executed after the slot methods have been executed. It can come in handy for disabling an intent if there are no slots to execute on, which can help the overall experience as a sentence that can't do anything shouldn't be registered in Rhasspy. To aid in disabling intents, there are two helper methods `intents.disable_intent` and `intents.disable_all`.

--- a/home_intent/audio_config.py
+++ b/home_intent/audio_config.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from typing import Set
 
 LOGGER = logging.getLogger(__name__)
 
@@ -36,8 +37,12 @@ class AudioConfig:
             _setup_nanotts_language(self.settings.home_intent.language, rhasspy_config)
         else:
             _setup_espeak_language(self.settings.home_intent.language, rhasspy_config)
+
         if self.settings.home_intent.beeps:
             self.setup_beeps(rhasspy_config)
+
+        if self.settings.rhasspy.satellite_ids:
+            _setup_satellite_ids(self.settings.rhasspy.satellite_ids, rhasspy_config)
 
     def setup_beeps(self, rhasspy_config):
         beep_high = self.get_file("beep-high.wav", language_dependent=False)
@@ -137,3 +142,15 @@ def _setup_espeak_language(language, rhasspy_config):
             rhasspy_config["text_to_speech"].update({"espeak": {"voice": language}})
     else:
         LOGGER.warning("Can only auto-setup language if 'text_to_speech' is set in profile.json")
+
+
+def _setup_satellite_ids(satellite_ids: Set[str], rhasspy_config):
+    satellite_ids_string = ",".join(satellite_ids)
+    if "dialogue" in rhasspy_config:
+        rhasspy_config["dialogue"]["satellite_site_ids"] = satellite_ids_string
+    if "intent" in rhasspy_config:
+        rhasspy_config["intent"]["satellite_site_ids"] = satellite_ids_string
+    if "speech_to_text" in rhasspy_config:
+        rhasspy_config["speech_to_text"]["satellite_site_ids"] = satellite_ids_string
+    if "text_to_speech" in rhasspy_config:
+        rhasspy_config["text_to_speech"]["satellite_site_ids"] = satellite_ids_string

--- a/home_intent/components/timer/base_timer.py
+++ b/home_intent/components/timer/base_timer.py
@@ -24,6 +24,7 @@ class BaseTimer:
 
     def _set_timer(
         self,
+        satellite_id,
         timer_done_message: str,
         hours: int = None,
         minutes: int = None,
@@ -32,7 +33,9 @@ class BaseTimer:
         text_conversion_function=humanize.precisedelta,
     ):
         timer_duration = timedelta(
-            hours=int(hours or 0), minutes=int(minutes or 0), seconds=int(seconds or 0),
+            hours=int(hours or 0),
+            minutes=int(minutes or 0),
+            seconds=int(seconds or 0),
         )
         if timer_duration == timedelta(0):
             raise TimerException("Timer has to be set for more than 0 seconds")
@@ -44,14 +47,14 @@ class BaseTimer:
         timer = ThreadingTimer(
             timer_duration.total_seconds(),
             self.complete_timer,
-            (human_timer_duration, timer_done_message),
+            (human_timer_duration, timer_done_message, satellite_id),
         )
         timer.start()
         return human_timer_duration
 
-    def complete_timer(self, human_timer_duration: str, timer_done_message: str):
+    def complete_timer(self, human_timer_duration: str, timer_done_message: str, satellite_id: str):
         self.home_intent.play_audio_file("timer/alarm.wav")
-        self.home_intent.say(timer_done_message.format(human_timer_duration))
+        self.home_intent.say(timer_done_message.format(human_timer_duration), satellite_id)
 
 
 def get_partial_time_duration(partial_time, hours=None, minutes=None, seconds=None):

--- a/home_intent/components/timer/en.py
+++ b/home_intent/components/timer/en.py
@@ -10,6 +10,7 @@ class Timer(BaseTimer):
             "and [a] third": "third",
         }
 
+    @intents.satellite_id
     @intents.sentences(
         [
             "time = 0..128",
@@ -24,9 +25,14 @@ class Timer(BaseTimer):
         ]
     )
     def set_timer(
-        self, hours: int = None, minutes: int = None, seconds: int = None, timer_partial_time=None
+        self,
+        satellite_id,
+        hours: int = None,
+        minutes: int = None,
+        seconds: int = None,
+        timer_partial_time=None,
     ):
         human_timer_duration = self._set_timer(
-            "Your timer {0} has ended", hours, minutes, seconds, timer_partial_time
+            satellite_id, "Your timer {0} has ended", hours, minutes, seconds, timer_partial_time
         )
         return f"Setting timer {human_timer_duration}"

--- a/home_intent/settings.py
+++ b/home_intent/settings.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Set
 
 from pydantic import AnyHttpUrl, BaseModel, BaseSettings, Field
 import yaml
@@ -44,6 +44,7 @@ class RhasspySettings(BaseModel):
     microphone_device: Optional[str] = None
     sounds_device: Optional[str] = None
     externally_managed: bool = False
+    satellite_ids: Optional[Set[str]] = None
 
 
 def get_env_language() -> str:


### PR DESCRIPTION
This should enable satellites that are configured in external rhasspy instances and are the first step in getting full support for satellites in Home Intent!

Should fix the bug in #258 